### PR TITLE
Stick to spark:2.4.5 for now,  instead of spark:latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ This project contains the following containers:
     * Port: 8282
 
 * spark: Spark Master.
-    * Image: bitnami/spark:latest
+    * Image: bitnami/spark:2.4.5
     * Port: 8181
     * References: https://github.com/bitnami/bitnami-docker-spark
 
 * spark-worker-N: Spark workers. You can add workers copying the containers and changing the container name inside the docker-compose.yml file.
-    * Image: bitnami/spark:latest
+    * Image: bitnami/spark:2.4.5
     * References: https://github.com/bitnami/bitnami-docker-spark
 
 * jupyter-spark: Jupyter notebook with pyspark for interactive development.
@@ -40,7 +40,7 @@ This project contains the following containers:
 ### Download Images
 
     $ docker pull postgres:9.6
-    $ docker pull bitnami/spark:latest
+    $ docker pull bitnami/spark:2.4.5
     $ docker pull jupyter/pyspark-notebook:latest
 
 ### Build airflow Docker
@@ -102,11 +102,11 @@ Jupyter Notebook: http://127.0.0.1:8888
 
 ## Increasing the number of Spark Workers
 
-You can increase the number of Spark workers just adding new services based on `bitnami/spark:latest` image to the `docker-compose.yml` file like following:
+You can increase the number of Spark workers just adding new services based on `bitnami/spark:2.4.5` image to the `docker-compose.yml` file like following:
 
 ```
 spark-worker-n:
-        image: bitnami/spark:latest
+        image: bitnami/spark:2.4.5
         networks:
             - default_net
         environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -41,7 +41,7 @@ services:
 
     # Spark with 3 workers
     spark:
-        image: bitnami/spark:latest
+        image: bitnami/spark:2.4.5
         hostname: spark
         networks:
             - default_net
@@ -59,7 +59,7 @@ services:
             - "7077:7077"
 
     spark-worker-1:
-        image: bitnami/spark:latest
+        image: bitnami/spark:2.4.5
         networks:
             - default_net
         environment:
@@ -76,7 +76,7 @@ services:
             - ../spark/resources/data:/usr/local/spark/resources/data #Data folder (Must be the same path in airflow and Spark Cluster)
 
     spark-worker-2:
-        image: bitnami/spark:latest
+        image: bitnami/spark:2.4.5
         networks:
             - default_net
         environment:
@@ -93,7 +93,7 @@ services:
             - ../spark/resources/data:/usr/local/spark/resources/data #Data folder (Must be the same path in airflow and Spark Cluster)
 
     spark-worker-3:
-        image: bitnami/spark:latest
+        image: bitnami/spark:2.4.5
         networks:
             - default_net
         environment:


### PR DESCRIPTION
Hi,

I setup a test env with the steps, then ran into a strange spark submission issue.
I suspected that was due to imcompatability between spark submission binaries and the cluster.

bitnami/spark:latest is currently based on spark 3.1.0,
while docker/docker-airflow/Dockerfile is still using 2.4.5 binaries.

I figure the solution is to either stick to spark 2.4.5 or upgrade the binaries under spark_files.
Thanks.